### PR TITLE
Exclude tests from packaged distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,8 @@ docs =
 all =
     %(docs)s
     %(test)s
+
+[options.packages.find]
+exclude =
+    tests
+    tests.*


### PR DESCRIPTION
A top-level `tests` package is usually a bad idea since it can be clobbered with other (mispackaged) distributions. If you want to distribute tests, they should be included within the main namespace of the package.

I am patching this as part of the review for the [conda-forge submission](https://github.com/conda-forge/staged-recipes/pull/17730).

Thanks!