### PR TITLE
Unpin setuptools-scm and clean build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 40.6.0",
-    "setuptools_scm[toml] >= 4, <6",
-    "setuptools_scm_git_archive",
-    "wheel"
+    "setuptools_scm[toml] >= 4",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
I would like to build [nixpkgs](https://github.com/NixOS/nixpkgs) this package using the latest version of setuptools-scm. In addition:

1. setuptools_scm_git_archive does not seem to be used, since there is no .git_archival.txt file
2. wheel should not be specified: see the note in [this section](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use)
